### PR TITLE
Implement login and registration initializations

### DIFF
--- a/backend/Dockerfile.api
+++ b/backend/Dockerfile.api
@@ -5,7 +5,7 @@ ARG NAME=chaturai
 ARG PORT=8000
 ARG HOME_DIR=/usr/src/${NAME}
 RUN apt-get update && apt-get install -y \
-    gcc libpq-dev wget git curl
+    gcc libpq-dev wget git curl && apt-get install tesseract-ocr -y
 
 RUN set -ex && apt-get autoremove -y --purge wget && rm -rf /var/lib/apt/lists/*
 

--- a/backend/src/chaturai/__init__.py
+++ b/backend/src/chaturai/__init__.py
@@ -128,7 +128,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     1. Load the embedding model.
     2. Connect to Redis.
-    3. Create graph descriptions for the Diagnostic Agent.
+    3. Create graph descriptions for ChaturAI.
     4. Yield control to the application.
     5. Close the Redis connection when the application finishes.
 
@@ -158,9 +158,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.success("Redis connection established!")
 
     # 3.
-    logger.info("Loading graph descriptions for the Diagnostic Agent...")
+    logger.info("Loading graph descriptions for ChaturAI...")
     create_graph_mappings()
-    logger.success("Finished loading graph descriptions for the Diagnostic Agent!")
+    logger.success("Finished loading graph descriptions for the ChaturAI!")
 
     logger.log("CELEBRATE", "Ready to roll! 🚀")
 

--- a/backend/src/chaturai/chatur/schemas.py
+++ b/backend/src/chaturai/chatur/schemas.py
@@ -124,12 +124,82 @@ class RegisterStudentQuery(BaseQuery):
 
         iti = info.data["is_iti_student"]
 
-        if v is not None and len(v) < 13:
-            raise ValueError(f"Roll number must be at least 13 digits: {v}")
+        if v is not None and len(v) != 13:
+            raise ValueError(f"Roll number must be exactly 13 digits: {v}")
         if iti and v is None:
             raise ValueError("roll_number is required when is_iti_student=True")
         if not iti and v is not None:
             raise ValueError("roll_number must be omitted when is_iti_student=False")
+
+        return v
+
+
+class RegisterStudentOTPQuery(BaseQuery):
+    """Pydantic model for validating student registration OTP queries."""
+
+    otp: str = Field(
+        ..., description="6-digit OTP sent to the registered mobile number"
+    )
+    type: Literal["registration_otp"]
+
+    @field_validator("otp")
+    @classmethod
+    def validate_otp(cls, v: str) -> str:
+        """Validate the OTP.
+
+        Parameters
+        ----------
+        v
+            The OTP to validate.
+
+        Returns
+        -------
+        str
+            The validated OTP.
+
+        Raises
+        ------
+        ValueError
+            If the OTP is not exactly 6 digits.
+        """
+
+        if not (v.isdigit() and len(v) == 6):
+            raise ValueError(f"OTP must be exactly 6 digits: {v}")
+
+        return v
+
+
+class RegisterStudentOTPQuery(BaseQuery):
+    """Pydantic model for validating student registration OTP queries."""
+
+    otp: str = Field(
+        ..., description="6-digit OTP sent to the registered mobile number and email"
+    )
+    type: Literal["registration_otp"]
+
+    @field_validator("otp")
+    @classmethod
+    def validate_otp(cls, v: str) -> str:
+        """Validate the OTP.
+
+        Parameters
+        ----------
+        v
+            The OTP to validate.
+
+        Returns
+        -------
+        str
+            The validated OTP.
+
+        Raises
+        ------
+        ValueError
+            If the OTP is not exactly 6 digits.
+        """
+
+        if not (v.isdigit() and len(v) == 6):
+            raise ValueError(f"OTP must be exactly 6 digits: {v}")
 
         return v
 

--- a/backend/src/chaturai/chatur/schemas.py
+++ b/backend/src/chaturai/chatur/schemas.py
@@ -205,7 +205,8 @@ class RegisterStudentOTPQuery(BaseQuery):
 
 
 ChaturQueryUnion = Annotated[
-    RegisterStudentQuery | LoginStudentQuery, Field(discriminator="type")
+    RegisterStudentQuery | RegisterStudentOTPQuery | LoginStudentQuery,
+    Field(discriminator="type"),
 ]
 
 

--- a/backend/src/chaturai/chatur/schemas.py
+++ b/backend/src/chaturai/chatur/schemas.py
@@ -134,78 +134,8 @@ class RegisterStudentQuery(BaseQuery):
         return v
 
 
-class RegisterStudentOTPQuery(BaseQuery):
-    """Pydantic model for validating student registration OTP queries."""
-
-    otp: str = Field(
-        ..., description="6-digit OTP sent to the registered mobile number"
-    )
-    type: Literal["registration_otp"]
-
-    @field_validator("otp")
-    @classmethod
-    def validate_otp(cls, v: str) -> str:
-        """Validate the OTP.
-
-        Parameters
-        ----------
-        v
-            The OTP to validate.
-
-        Returns
-        -------
-        str
-            The validated OTP.
-
-        Raises
-        ------
-        ValueError
-            If the OTP is not exactly 6 digits.
-        """
-
-        if not (v.isdigit() and len(v) == 6):
-            raise ValueError(f"OTP must be exactly 6 digits: {v}")
-
-        return v
-
-
-class RegisterStudentOTPQuery(BaseQuery):
-    """Pydantic model for validating student registration OTP queries."""
-
-    otp: str = Field(
-        ..., description="6-digit OTP sent to the registered mobile number and email"
-    )
-    type: Literal["registration_otp"]
-
-    @field_validator("otp")
-    @classmethod
-    def validate_otp(cls, v: str) -> str:
-        """Validate the OTP.
-
-        Parameters
-        ----------
-        v
-            The OTP to validate.
-
-        Returns
-        -------
-        str
-            The validated OTP.
-
-        Raises
-        ------
-        ValueError
-            If the OTP is not exactly 6 digits.
-        """
-
-        if not (v.isdigit() and len(v) == 6):
-            raise ValueError(f"OTP must be exactly 6 digits: {v}")
-
-        return v
-
-
 ChaturQueryUnion = Annotated[
-    RegisterStudentQuery | RegisterStudentOTPQuery | LoginStudentQuery,
+    RegisterStudentQuery | LoginStudentQuery,
     Field(discriminator="type"),
 ]
 

--- a/backend/src/chaturai/chatur/utils.py
+++ b/backend/src/chaturai/chatur/utils.py
@@ -2,6 +2,7 @@
 
 # Third Party Library
 import cv2
+import numpy as np
 import pytesseract
 
 from playwright.async_api import Error as PlaywrightError
@@ -98,6 +99,7 @@ async def solve_and_fill_captcha(page: Page):
     """Solve the CAPTCHA and fill it in the form."""
     canvas = page.locator("canvas.captcha-canvas")
     await canvas.wait_for(state="visible")
+    await canvas.scroll_into_view_if_needed()
     captcha_bytes: bytes = await canvas.screenshot()
 
     captcha_text = await solve_captcha(captcha_bytes)
@@ -122,7 +124,9 @@ def preprocess_captcha_image(image_buffer: bytes):
         jcv2.imshow("label", img, colorspace="gray")
 
     """
-    img = cv2.imdecode(image_buffer)
+    img_array = np.asarray(bytearray(image_buffer), dtype="uint8")
+
+    img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
 
     img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 

--- a/backend/src/chaturai/chatur/utils.py
+++ b/backend/src/chaturai/chatur/utils.py
@@ -1,6 +1,9 @@
 """This module contains utilities for chatur."""
 
 # Third Party Library
+import cv2
+import pytesseract
+
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import Page
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
@@ -73,7 +76,6 @@ async def select_register_radio(*, page: Page, timeout: int = 10_000) -> None:
         If the register form does not appear within the timeout or if the radio button
         is not checked.
     """
-
     # 1.
     await page.locator("label:has-text('Register as a candidate')").click(force=True)
 
@@ -90,3 +92,57 @@ async def select_register_radio(*, page: Page, timeout: int = 10_000) -> None:
     # 3.
     if not await page.locator("input#disnoCan").is_checked():
         raise RuntimeError("Radio ‘Register as a candidate’ was not checked.")
+
+
+async def solve_and_fill_captcha(page: Page):
+    """Solve the CAPTCHA and fill it in the form."""
+    canvas = page.locator("canvas.captcha-canvas")
+    await canvas.wait_for(state="visible")
+    captcha_bytes: bytes = await canvas.screenshot()
+
+    captcha_text = await solve_captcha(captcha_bytes)
+
+    await page.fill('input[placeholder="Enter CAPTCHA"]', captcha_text)
+
+
+async def solve_captcha(image_buffer: bytes) -> str:
+    """Extract captcha text from image."""
+    preprocessed_img = preprocess_captcha_image(image_buffer)
+    captcha_text = pytesseract.image_to_string(preprocessed_img)
+    return captcha_text.strip()
+
+
+def preprocess_captcha_image(image_buffer: bytes):
+    """
+    Preprocess the captcha image to improve OCR accuracy.
+
+    NB: For debugging use
+
+        import opencv_jupyter_ui as jcv2
+        jcv2.imshow("label", img, colorspace="gray")
+
+    """
+    img = cv2.imdecode(image_buffer)
+
+    img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+
+    img_contrast = cv2.convertScaleAbs(img_gray, alpha=2, beta=0)
+
+    threshold_value = 127
+    _, img_thrshold = cv2.threshold(
+        img_contrast, threshold_value, 255, cv2.THRESH_BINARY
+    )
+    return img_thrshold
+
+
+async def submit_and_capture_api_response(
+    page: Page, button_name: str, api_url: str
+) -> dict:
+    """Click a button and wait for the page to navigate."""
+    async with page.expect_response(
+        lambda response: api_url in response.url
+    ) as response_info:
+        await page.get_by_role("button", name=button_name, exact=True).click()
+
+    response = await response_info.value
+    return response.json()

--- a/backend/src/chaturai/graphs/chatur.py
+++ b/backend/src/chaturai/graphs/chatur.py
@@ -134,7 +134,7 @@ class SelectStudentOrAssistant(BaseNode[ChaturState, ChaturDeps, ChaturFlowResul
         graph_mapping = Settings._INTERNAL_GRAPH_MAPPING or create_graph_mappings()
         key = "adj_list" if self.student_intent == "proceed" else "adj_list_reverse"
         if ctx.state.last_assistant_call is None:
-            valid_assistants = [self._default_first_assistant]
+            valid_assistants = graph_mapping[self._default_first_assistant][key]
         else:
             valid_assistants = graph_mapping[ctx.state.last_assistant_call][key]
         assistant_names_and_descriptions = [

--- a/backend/src/chaturai/graphs/login.py
+++ b/backend/src/chaturai/graphs/login.py
@@ -143,6 +143,10 @@ class LoginExistingStudent(
             # 5.
             await solve_and_fill_captcha(page=page)
 
+            # TODO: Remove this
+            # Pause to verify in the browser. Can remove this later.
+            await asyncio.get_event_loop().run_in_executor(None, input)
+
             # 6. Request OTP
             response_json = await submit_and_capture_api_response(
                 page=page,
@@ -173,9 +177,6 @@ class LoginExistingStudent(
                 )
 
             # TODO: handle error cases better
-
-            # Pause to verify in the browser. Can remove this later.
-            await asyncio.get_event_loop().run_in_executor(None, input)
 
             # 7.
             await save_browser_state(page=page, redis_client=ctx.deps.redis_client)

--- a/backend/src/chaturai/graphs/registration.py
+++ b/backend/src/chaturai/graphs/registration.py
@@ -19,6 +19,8 @@ persisted page to the next assistant.
 # Standard Library
 
 # Standard Library
+import asyncio
+
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Annotated, Any
@@ -231,9 +233,9 @@ class RegisterNewStudent(
             # 5.
             await solve_and_fill_captcha(page=page)
 
-            # Wait for timeout for demo
-            # TODO: remove this later
-            await page.wait_for_timeout(500)
+            # TODO: Remove this
+            # Pause to verify in the browser. Can remove this later.
+            await asyncio.get_event_loop().run_in_executor(None, input)
 
             # 6.
             response_json = await submit_and_capture_api_response(

--- a/backend/src/chaturai/graphs/registration.py
+++ b/backend/src/chaturai/graphs/registration.py
@@ -5,7 +5,7 @@ The student registration graph does the following:
 1. Navigate to the `Register as a candidate` page and auto-fill the required fields.
 2. If the student is an ITI student, then it will fill out the roll number:
     2.1 Find additional details regarding the student.
-    2.2 XXX
+    2.2 XXX # TODO: Test with ITI roll number.
 3. Solve the text-based CAPTCHA.
 4. Submit the registration form.
 5. Return the graph run results containing (among other things) the persisted **page**
@@ -289,6 +289,8 @@ async def register_student(
             going on between you and the student!**
 
     🚫 DO NOT USE THIS ASSISTANT IF
+        - You are trying to **continue the registration process** for a student who
+            already initiated the registration process.
         - You are trying to **log in a student who already has an account**.
         - You are trying to **continue the application or document submission** process
             for a student with an existing account.

--- a/cicd/deployment/docker-compose/docker-compose.dev.yml
+++ b/cicd/deployment/docker-compose/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     command: >
       /bin/sh -c "
       python -m alembic upgrade head &&
-      python main.py"
+      python src/chaturai/entries/main.py"
 
   litellm-proxy:
     command: ["--config", "/app/config.yaml", "--detailed_debug", "--telemetry", "False"]

--- a/cicd/litellm/litellm_config.yaml
+++ b/cicd/litellm/litellm_config.yaml
@@ -36,8 +36,8 @@ model_list:
   # Do NOT change the model name for chat unless you really know what you are doing since it is used in the backend code!
   - model_name: chat
     litellm_params:
-      litellm_credential_name: default_vertexai_credential
-      model: vertex_ai/gemini-2.0-flash
+      litellm_credential_name: default_openai_credential
+      model: gpt-4o
 
   - model_name: default
     litellm_params:

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,8 +3,8 @@ import {Geist, Geist_Mono} from "next/font/google";
 import "./globals.css";
 
 export const metadata: Metadata = {
-	title: "Diagnostic Agent",
-	description: "Diagnostic agent using Graph RAG.",
+	title: "ChaturAI",
+	description: "ChaturAI using Graph RAG.",
 };
 
 /**

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -22,7 +22,7 @@ export default function Footer() {
 					MIT License © {new Date().getFullYear()} - IDinsight |
 					<strong>
 						{" "}
-						Diagnostic Assistant can make mistakes. Check important info!
+						Chatur can make mistakes. Check important info!
 					</strong>
 				</p>
 			</aside>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -26,7 +26,7 @@ export default function NavBar({toggleDrawer}: {toggleDrawer: () => void}) {
 						</svg>
 					</button>
 					<a className="btn text-xl whitespace-nowrap btn-ghost">
-						Diagnostic Assistant v0.1
+						ChaturAI v0.1
 					</a>
 				</div>
 


### PR DESCRIPTION
# Goal

Complete the login and registration graphs. Each should now take in its appropriate input and run until the OTP field is shown.

# Changes

- Add util functions for solving Captcha and submitting forms
- Complete the steps in registration and login run functions. We stop before the OTP field page appears.

# How to test

Set up dev app:

```
cd chaturai
make up

cd backend
python src/chaturai/entries/main.py
```

Go to Swagger UI: http://localhost:8000/docs#/Chatur/chatur_flow_chatur_flow_post and test the endpoint

```
{
  "type": "registration",
  "user_query": "Please register me",
  "user_id": "1",
  "email": "<random email>",
  "is_iti_student": false,
  "is_new_student": false,
  "mobile_number": "<random phone number>"
} 
```

The agent should select the `registration.register_student` assistant and run stuff in the browser.

If the browser run pauses, press Enter to proceed.

Sometimes, the captcha solving fails. In that case try again with the same inputs.

Make sure you receive a response asking for OTP.


Now, test the login. Try using a new user ID
```
{
  "type": "login",
  "user_query": "Please login",
  "user_id": "3",
  "email": "<registered email>"
} 
```

The agent should select the `login.login_student` assistant and run stuff in the browser.

If the browser run pauses, press Enter to proceed.

Make sure you receive a response asking for OTP.


# Future work

- use better OCR than tesseract!
- language layer (hindi)
- OTP util
- profile completion
- ...