### PR TITLE
Add retry captcha

### DIFF
--- a/backend/src/chaturai/chatur/schemas.py
+++ b/backend/src/chaturai/chatur/schemas.py
@@ -134,9 +134,45 @@ class RegisterStudentQuery(BaseQuery):
         return v
 
 
+class RegisterStudentOTPQuery(BaseQuery):
+    """Pydantic model for validating student registration OTP queries."""
+
+    otp: str = Field(
+        ..., description="6-digit OTP sent to the registered mobile number"
+    )
+    type: Literal["registration_otp"]
+
+    @field_validator("otp")
+    @classmethod
+    def validate_otp(cls, v: str) -> str:
+        """Validate the OTP.
+
+        Parameters
+        ----------
+        v
+            The OTP to validate.
+
+        Returns
+        -------
+        str
+            The validated OTP.
+
+        Raises
+        ------
+        ValueError
+            If the OTP is not exactly 6 digits.
+        """
+
+        if not (v.isdigit() and len(v) == 6):
+            raise ValueError(f"OTP must be exactly 6 digits: {v}")
+
+        return v
+
+
 ChaturQueryUnion = Annotated[
-    RegisterStudentQuery | LoginStudentQuery,
-    Field(discriminator="type"),
+    RegisterStudentQuery | LoginStudentQuery | RegisterStudentOTPQuery,
+   
+    Field(discriminator="type"),,
 ]
 
 

--- a/backend/src/chaturai/chatur/schemas.py
+++ b/backend/src/chaturai/chatur/schemas.py
@@ -47,6 +47,9 @@ class RegisterStudentQuery(BaseQuery):
         None,
         description="At least 13-digit roll number; required if is_iti_student=True",
     )
+    otp: Optional[str] = Field(
+        ..., description="6-digit OTP sent to the registered mobile number if available"
+    )
     type: Literal["registration"]
 
     @field_validator("mobile_number")
@@ -133,15 +136,6 @@ class RegisterStudentQuery(BaseQuery):
 
         return v
 
-
-class RegisterStudentOTPQuery(BaseQuery):
-    """Pydantic model for validating student registration OTP queries."""
-
-    otp: str = Field(
-        ..., description="6-digit OTP sent to the registered mobile number"
-    )
-    type: Literal["registration_otp"]
-
     @field_validator("otp")
     @classmethod
     def validate_otp(cls, v: str) -> str:
@@ -170,9 +164,8 @@ class RegisterStudentOTPQuery(BaseQuery):
 
 
 ChaturQueryUnion = Annotated[
-    RegisterStudentQuery | LoginStudentQuery | RegisterStudentOTPQuery,
-   
-    Field(discriminator="type"),,
+    RegisterStudentQuery | LoginStudentQuery,
+    Field(discriminator="type"),
 ]
 
 
@@ -204,3 +197,22 @@ class LoginStudentResults(PageResults):
 
 class RegisterStudentResults(PageResults):
     """Pydantic model for validating register student results."""
+
+
+# Adding these for now. Might remove later.
+class RegisterationCompleteResults(PageResults):
+    """Pydantic model for validating register activation link send results."""
+
+    naps_id: str
+    activation_link_expiry: str
+
+
+class SubmitButtonResponse(BaseModel):
+    """Pydantic model for validating submit button response."""
+
+    is_error: bool
+    is_success: bool
+    message: str
+    source: Literal["toast", "api", "timeout"]
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/src/chaturai/chatur/utils.py
+++ b/backend/src/chaturai/chatur/utils.py
@@ -1,13 +1,23 @@
 """This module contains utilities for chatur."""
 
+# Standard Library
+import asyncio
+import random
+
+from typing import Any
+
 # Third Party Library
 import cv2
 import numpy as np
 import pytesseract
 
+from loguru import logger
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import Page
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
+# Package Library
+from chaturai.chatur.schemas import SubmitButtonResponse
 
 
 async def select_login_radio(*, page: Page) -> None:
@@ -95,6 +105,43 @@ async def select_register_radio(*, page: Page, timeout: int = 10_000) -> None:
         raise RuntimeError("Radio ‘Register as a candidate’ was not checked.")
 
 
+async def solve_and_submit_captcha_with_retries(
+    page: Page,
+    api_url: str,
+    button_name: str,
+    timeout: int = 5000,
+    max_retries: int = 3,
+) -> SubmitButtonResponse:
+    """Solve the CAPTCHA and submit the form with retries."""
+    try_count = 0
+    wait_ms = random.randint(1500, 3000)
+    while try_count < max_retries:
+        await page.wait_for_timeout(wait_ms)
+
+        await solve_and_fill_captcha(page=page)
+
+        # TODO: remove this line
+        logger.debug(
+            f"Remaining retries: {max_retries-try_count}. Press Enter to continue.. "
+        )
+        await asyncio.get_event_loop().run_in_executor(None, input)
+
+        response = await submit_and_capture_api_response(
+            page=page,
+            api_url=api_url,
+            button_name=button_name,
+            timeout=timeout,
+        )
+
+        if "captcha" in response.message.lower():
+            try_count += 1
+            continue
+        elif response.is_error:
+            raise RuntimeError(f"Error: {response.message}")
+        else:
+            return response
+
+
 async def solve_and_fill_captcha(page: Page):
     """Solve the CAPTCHA and fill it in the form."""
     canvas = page.locator("canvas.captcha-canvas")
@@ -140,13 +187,157 @@ def preprocess_captcha_image(image_buffer: bytes):
 
 
 async def submit_and_capture_api_response(
-    page: Page, button_name: str, api_url: str
-) -> dict:
+    page: Page, button_name: str, api_url: str, timeout: int = 5000
+) -> SubmitButtonResponse:
     """Click a button and wait for the page to navigate."""
-    async with page.expect_response(
-        lambda response: api_url in response.url
-    ) as response_info:
-        await page.get_by_role("button", name=button_name, exact=True).click()
 
-    response = await response_info.value
-    return response.json()
+    async def check_for_toast():
+        """Wait for a toast message to appear and parse the response"""
+        try:
+            # Wait for any toast message to appear
+            toast_message = await page.wait_for_selector(
+                "#toast-container .toast-message", state="attached", timeout=timeout
+            )
+
+            # Check if it's an error or success toast
+            is_error = await page.locator("#toast-container .toast-error").is_visible()
+            is_success = await page.locator(
+                "#toast-container .toast-success"
+            ).is_visible()
+
+            # Get the message text
+            message_text = await toast_message.text_content()
+            message_text = message_text.strip()
+
+            return SubmitButtonResponse(
+                source="toast",
+                message=message_text,
+                is_error=is_error,
+                is_success=is_success,
+            )
+        except PlaywrightTimeoutError:
+            # No toast appeared within the timeout
+            return None
+
+    # Function to wait for API response
+    async def wait_for_api():
+        """Wait for API response and parse the response"""
+        try:
+            async with page.expect_response(
+                lambda response: api_url in response.url, timeout=timeout
+            ) as response_info:
+                pass  # We'll click the button outside this context
+
+            response = await response_info.value
+
+            json_response = await response.json()
+
+            if "errors" in json_response:
+                # json_response["errors"] is keyed by fields with error message values.
+                message_text = " ".join(json_response["errors"].values())
+                is_error = True
+                is_success = False
+            elif "message" in json_response:
+                message_text = json_response["message"]
+                if "status" in json_response:
+                    is_success = json_response["status"] == "success"
+                    is_error = json_response["status"] == "error"
+            else:
+                message_text = ""
+                is_success = response.ok
+                is_error = not response.ok
+
+            return SubmitButtonResponse(
+                source="api",
+                message=message_text,
+                is_error=is_error,
+                is_success=is_success,
+            )
+        except PlaywrightTimeoutError:
+            return None
+
+    # Click the button
+    await page.get_by_role("button", name=button_name, exact=True).click()
+
+    # Start both waiters
+    toast_task = asyncio.create_task(check_for_toast())
+    api_task = asyncio.create_task(wait_for_api())
+
+    # Wait for either the toast or API response to happen first
+    done, pending = await asyncio.wait(
+        [toast_task, api_task],
+        return_when=asyncio.FIRST_COMPLETED,
+        timeout=timeout / 1000,  # Convert to seconds
+    )
+
+    # Cancel any pending tasks
+    for task in pending:
+        task.cancel()
+
+    # If we got a toast message first, check if it's a captcha error
+    if toast_task in done:
+        toast_result = await toast_task
+        if toast_result:
+            # If it's a captcha error, the API call won't happen
+            if "Captcha" in toast_result["message"]:
+                return toast_result
+
+    # If we got an API response
+    if api_task in done:
+        api_result = await api_task
+        if api_result:
+            return api_result
+
+    # If we made it here, check if either task completed
+    for task in done:
+        try:
+            result = await task
+            if result:
+                return result
+        except Exception:
+            pass
+
+    # If nothing happened, return a timeout error
+    return SubmitButtonResponse(
+        source="timeout",
+        message="No toast or API response detected",
+        is_error=True,
+        is_success=False,
+    )
+
+
+# TODO: update return values and type after implementing browser session management
+async def submit_register_otp(page: Page, otp: str) -> Any:
+    """Enter the OTP in the OTP input field.
+
+    Parameters
+    ----------
+    page
+        The Playwright page object.
+    otp
+        The OTP to enter.
+    """
+    otp_field = page.locator("input[placeholder='Enter 6 Digit OTP']")
+    await otp_field.click()
+    await otp_field.fill(otp)
+    await otp_field.scroll_into_view_if_needed()
+
+    response_json = await submit_and_capture_api_response(
+        page=page,
+        api_url="https://api.apprenticeshipindia.gov.in/auth/register-otp",
+        button_name="Submit",
+    )
+
+    response = await response_json
+    if "status" in response and response["status"] == "success":
+        data = response.get("data")
+        candidate_info = data.get("candidate")
+        naps_id = candidate_info["code"]
+        activation_link_expiry = candidate_info["activation_link_expiry_date"]
+
+        return naps_id, activation_link_expiry
+    else:
+        assert "errors" in response
+        error_messages = response["errors"].values()
+        message = " ".join(error_messages)
+        raise RuntimeError(f"Error: {message}")

--- a/backend/src/chaturai/graphs/registration.py
+++ b/backend/src/chaturai/graphs/registration.py
@@ -211,6 +211,7 @@ class RegisterSubmitOTP(
             The results of the graph run.
         """
 
+        # TODO: update this logic to use browser session management
         browser_state = await load_browser_state(
             redis_client=ctx.deps.redis_client,
         )
@@ -238,13 +239,6 @@ class RegisterSubmitOTP(
             )
             response = await response_json
 
-            response_json = await submit_and_capture_api_response(
-                page=page,
-                api_url="https://api.apprenticeshipindia.gov.in/auth/register-otp",
-                button_name="Submit",
-            )
-
-            response = await response_json
             if "status" in response and response["status"] == "success":
                 data = response.get("data")
                 candidate_info = data.get("candidate")


### PR DESCRIPTION
Reviewer:
Estimate:

---

## Ticket

Fixes: 

## Goal

Add retry logic for captcha.

Was going to implement OTP submissions, but will put that off till we implement browser session management!

## Main Changes

1. `submit_and_capture_api_response` now watches for both API response and toast messages. Captcha check happens before the browser makes the API request, so this was necessary.
2. Also implemented convenience function `solve_and_submit_captcha_with_retries` specifically for captcha. With enough retries we can avoid implementing heavier OCR models for now, for vast majority of cases. But not a foolproof method of course.
3. Also added some OTP submission related code for later use!

## Future Tasks (optional)

## How has this been tested?

It's a bit tricky to test because we need tesseract OCR to fail and retry.

Run the Fast API app

```
make up
cd backend
python src/chaturai/entries/main.py
```

And try registering or logging in. The browser will pause for Enter after filling each captcha (in the terminal).

## To-do before merge (optional)

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have ensured that my PR branch is up to date with `main`

(Delete any items below that are not relevant)

- [ ] I have updated the test suite
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
