### PR TITLE
Disabling logfire logging to console.

### DIFF
--- a/backend/src/chaturai/utils/logging_.py
+++ b/backend/src/chaturai/utils/logging_.py
@@ -153,7 +153,7 @@ def initialize_logger(
             repository="https://github.com/IDinsight/chaturai",
             revision="main",
         ),
-        console=logfire.ConsoleOptions(min_log_level=LOGGING_LOG_LEVEL.lower()),
+        console=False,
     )
 
     # Remove any default handlers attached to the root logger.


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: ~2 min.

Thought I'd fix this annoying issue where loguru and logfire are both logging to console.

Now, only loguru logs to console and logfire should log to its own servers. hopefully much cleaner terminal now!

---

## Ticket

Fixes: JIRA_TICKET_LINK

## Goal

## Main Changes

## Future Tasks (optional)

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have ensured that my PR branch is up to date with `main`

(Delete any items below that are not relevant)

- [ ] I have updated the test suite
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
