### PR TITLE
[Fixes: #21] Handle multiple errors

### DIFF
--- a/backend/src/chaturai/chatur/schemas.py
+++ b/backend/src/chaturai/chatur/schemas.py
@@ -18,6 +18,7 @@ from pydantic import (
     ValidationInfo,
     field_validator,
 )
+from pydantic.json_schema import SkipJsonSchema
 
 
 class NextChatAction(str, Enum):
@@ -39,7 +40,7 @@ class BaseQuery(BaseModel):
     email: EmailStr
     otp: Optional[str] = Field(None, description="6-digit OTP sent to the student")
     user_query: Optional[str] = Field(None, description="The student's message")
-    user_query_translated: str | None = Field(
+    user_query_translated: SkipJsonSchema[str | None] = Field(
         None, description="Translated student message"
     )
     user_id: str
@@ -113,22 +114,15 @@ class RegisterStudentQuery(BaseQuery):
         """
 
         # 1.
-        if v.startswith("+"):
-            v = v[1:]
-
-        # 2.
-        if v.startswith("91") and len(v) > 10:
-            v = v[2:]
-
-        # 3.
         pattern = r"^(?:\+?91\s*)?([1-9](?:\d\s*){9})$"
         match = re.match(pattern, v)
+
         if not match:
             raise ValueError(
                 f"Expected a 10-digit number starting with 1-9 (ignoring +91 country code) but got {v}."
             )
 
-        # 4.
+        # 2.
         phone_number = match.group(1)
         stripped_phone_number = re.sub(r"\s+", "", phone_number)
         return stripped_phone_number

--- a/backend/src/chaturai/chatur/utils.py
+++ b/backend/src/chaturai/chatur/utils.py
@@ -545,6 +545,12 @@ async def submit_and_capture_api_response(
             assert message_text is not None
             message_text = message_text.strip()
 
+            # Close current toast messages
+            all_toasts = await page.locator("#toast-container .toast-message").all()
+            for toast_handle in all_toasts:
+                if await toast_handle.is_visible():
+                    await toast_handle.click(timeout=100)
+
             return SubmitButtonResponse(
                 api_response=None,
                 is_error=is_error,

--- a/backend/src/chaturai/chatur/utils.py
+++ b/backend/src/chaturai/chatur/utils.py
@@ -497,21 +497,30 @@ async def submit_and_capture_api_response(
             toast_message = await page.wait_for_selector(
                 "#toast-container .toast-message", state="attached", timeout=timeout
             )
-            # Check if it's an error or success toast.
-            is_error = await page.locator("#toast-container .toast-error").is_visible()
-            is_success = await page.locator(
-                "#toast-container .toast-success"
-            ).is_visible()
 
-            # Get the message text.
+            # Check for error toasts
+            error_locator = page.locator("#toast-container .toast-error")
+            is_error_present = await error_locator.first.is_visible()
+
+            if is_error_present:
+                is_error = True  # Set main error flag
+            else:
+                is_error = False
+
+            # Check for success toast
+            success_locator = page.locator("#toast-container .toast-success")
+            is_success_present = await success_locator.is_visible()
+
+            if is_success_present:
+                is_success = True  # Set main success flag
+            else:
+                is_success = False
+
+            # Get the message text across all toasts.
             assert toast_message is not None
             message_text = await toast_message.text_content()
             assert message_text is not None
             message_text = message_text.strip()
-
-            # Close the toast message to avoid having multiple toasts.
-            # TODO: Handle multiple toasts.
-            await page.locator("#toast-container .toast-error").click()
 
             return SubmitButtonResponse(
                 api_response=None,

--- a/backend/src/chaturai/chatur/utils.py
+++ b/backend/src/chaturai/chatur/utils.py
@@ -93,8 +93,8 @@ def extract_otp(message: str) -> str:
     match = re.search(r"(?<!\d)\d{6}(?!\d)", message)
     if match:
         return match.group(0)
-    else:
-        raise ValueError(f"OTP not found in the message: {message}")
+
+    raise ValueError(f"OTP not found in the message: {message}")
 
 
 async def fill_login_email(*, email: str, page: Page, url: str) -> None:
@@ -523,21 +523,11 @@ async def submit_and_capture_api_response(
 
             # Check for error toasts
             error_locator = page.locator("#toast-container .toast-error")
-            is_error_present = await error_locator.first.is_visible()
-
-            if is_error_present:
-                is_error = True  # Set main error flag
-            else:
-                is_error = False
+            is_error = await error_locator.first.is_visible()
 
             # Check for success toast
             success_locator = page.locator("#toast-container .toast-success")
-            is_success_present = await success_locator.is_visible()
-
-            if is_success_present:
-                is_success = True  # Set main success flag
-            else:
-                is_success = False
+            is_success = await success_locator.is_visible()
 
             # Get the message text across all toasts.
             assert toast_message is not None

--- a/backend/src/chaturai/chatur/utils.py
+++ b/backend/src/chaturai/chatur/utils.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import random
+import re
 
 from contextlib import suppress
 from functools import wraps
@@ -72,6 +73,28 @@ def check_chatur_agent_translation_response(content: str) -> None:
     assert generated_response[
         "translated_text"
     ], "`translated_text` key must not be empty."
+
+
+def extract_otp(message: str) -> str:
+    """Look for a 6-digit number in the message, not preceded or followed by
+    another digit.
+
+    Parameters
+    ----------
+    message
+        The message containing the OTP.
+
+    Returns
+    -------
+    str
+        The extracted OTP.
+    """
+
+    match = re.search(r"(?<!\d)\d{6}(?!\d)", message)
+    if match:
+        return match.group(0)
+    else:
+        raise ValueError(f"OTP not found in the message: {message}")
 
 
 async def fill_login_email(*, email: str, page: Page, url: str) -> None:
@@ -380,7 +403,7 @@ async def solve_and_submit_captcha_with_retries(
     """
 
     for attempt in range(max_retries):
-        await page.wait_for_timeout(random.randint(1500, 3000))
+        await page.wait_for_timeout(random.randint(1000, 2000))
         await solve_and_fill_captcha(page=page)
 
         if not Settings.PLAYWRIGHT_HEADLESS:

--- a/backend/src/chaturai/chatur/utils.py
+++ b/backend/src/chaturai/chatur/utils.py
@@ -461,8 +461,8 @@ async def submit_and_capture_api_response(
             json_response = await response.json()
 
             if "errors" in json_response:
-                # json_response["errors"] is keyed by fields with error message values.
-                message_text = " ".join(json_response["errors"].values())
+                # json_response["errors"] is keyed by fields with error messages list values.
+                message_text = " ".join(*zip(*json_response["errors"].values()))
                 is_error = True
                 is_success = False
             elif "message" in json_response:

--- a/backend/src/chaturai/graphs/profile.py
+++ b/backend/src/chaturai/graphs/profile.py
@@ -146,7 +146,6 @@ class CompleteStudentProfile(
         else:
             # 3.
             otp_text = match.group()
-            logger.info(f"OTP text: {otp_text}")
 
             await fill_otp(
                 otp=otp_text,

--- a/backend/src/chaturai/graphs/profile.py
+++ b/backend/src/chaturai/graphs/profile.py
@@ -7,6 +7,7 @@ The profile completion graph does the following:
 
 # Standard Library
 import asyncio
+import re
 
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -124,45 +125,67 @@ class CompleteStudentProfile(
         page = browser_session.page
 
         # 2.
-        await fill_otp(
-            otp=ctx.deps.profile_completion_query.otp
-            or ctx.deps.profile_completion_query.user_query_translated,
-            page=page,
+        otp_message = (
+            ctx.deps.profile_completion_query.otp
+            or ctx.deps.profile_completion_query.user_query_translated
         )
 
         # 3.
-        submit_otp_response = await submit_and_capture_api_response(
-            page=page, api_url=ctx.deps.login_otp_url, button_name="Login"
-        )
-
-        logger.info(f"{submit_otp_response = }")
-
-        if not Settings.PLAYWRIGHT_HEADLESS:
-            await asyncio.get_event_loop().run_in_executor(None, input)
-
-        # 4.
-        if submit_otp_response.is_error:
-            end = End(
-                ProfileCompletionResults(  # type: ignore
-                    next_chat_action=NextChatAction.GO_TO_HELPDESK,
-                    session_id=ctx.state.session_id,
-                    summary_of_page_results=f"Cannot complete login. {submit_otp_response.message}",
-                )
-            )
-        else:
-            # TODO: Do not return an End object but pass on to other assistants.
+        # Look for a 6-digit number in the message, not preceded or followed by
+        # another digit.
+        match = re.search(r"(?<!\d)\d{6}(?!\d)", otp_message)
+        if not match:
             end = End(
                 ProfileCompletionResults(  # type: ignore
                     next_chat_action=NextChatAction.REQUEST_USER_QUERY,
                     session_id=ctx.state.session_id,
-                    summary_of_page_results="OTP successfully entered. "
-                    "Determine the next best assistant to call based on the student's "
-                    "latest message and your conversation with the student so far. If "
-                    "unclear, ask the student what they wish to do next.",
+                    summary_of_page_results=f"Cannot complete login. OTP not found "
+                    f"in the message: {otp_message}",
                 )
             )
+        else:
+            # 3.
+            otp_text = match.group()
+            logger.info(f"OTP text: {otp_text}")
 
-        # 5.
+            await fill_otp(
+                otp=otp_text,
+                page=page,
+            )
+
+            # 4.
+            submit_otp_response = await submit_and_capture_api_response(
+                page=page, api_url=ctx.deps.login_otp_url, button_name="Login"
+            )
+
+            logger.info(f"{submit_otp_response = }")
+
+            if not Settings.PLAYWRIGHT_HEADLESS:
+                await asyncio.get_event_loop().run_in_executor(None, input)
+
+            # 5.
+            if submit_otp_response.is_error:
+                end = End(
+                    ProfileCompletionResults(  # type: ignore
+                        next_chat_action=NextChatAction.GO_TO_HELPDESK,
+                        session_id=ctx.state.session_id,
+                        summary_of_page_results=f"Cannot complete login. {submit_otp_response.message}",
+                    )
+                )
+            else:
+                # TODO: Do not return an End object but pass on to other assistants.
+                end = End(
+                    ProfileCompletionResults(  # type: ignore
+                        next_chat_action=NextChatAction.REQUEST_USER_QUERY,
+                        session_id=ctx.state.session_id,
+                        summary_of_page_results="OTP successfully entered. "
+                        "Determine the next best assistant to call based on the student's "
+                        "latest message and your conversation with the student so far. If "
+                        "unclear, ask the student what they wish to do next.",
+                    )
+                )
+
+        # 6.
         await persist_browser_and_page(
             browser=browser_session.browser,  # Reuse the same browser here!
             browser_session_store=ctx.deps.browser_session_store,

--- a/backend/src/chaturai/graphs/profile.py
+++ b/backend/src/chaturai/graphs/profile.py
@@ -132,7 +132,7 @@ class CompleteStudentProfile(
 
         try:
             # 3.
-            otp_text = extract_otp(otp_message=otp_message)
+            otp_text = extract_otp(otp_message)
 
             # 4.
             await fill_otp(otp=otp_text, page=page)

--- a/backend/src/chaturai/graphs/registration.py
+++ b/backend/src/chaturai/graphs/registration.py
@@ -296,7 +296,7 @@ class RegisterNewStudent(
             message = (
                 "Initiated account creation successfully. "
                 "Ask the student to share the OTP. It should be sent to the "
-                "mobile number or the email address."
+                "mobile number."
             )
             next_action = NextChatAction.REQUEST_OTP
         except RuntimeError as e:

--- a/backend/src/chaturai/graphs/registration.py
+++ b/backend/src/chaturai/graphs/registration.py
@@ -217,7 +217,7 @@ class RegisterNewStudent(
 
             try:
                 # 2.2.
-                otp_text = extract_otp(otp_message=otp_message)
+                otp_text = extract_otp(otp_message)
 
                 # 2.3.
                 await fill_otp(otp=otp_text, page=page)


### PR DESCRIPTION
Reviewer: @tonyzhao6 
Estimate: 15 min

---

## Ticket

Fixes: #21 

## Goal

Handle cases where there are multiple toast errors

## Main Changes

1. Fixed a bug in extracting error messages from API response
2. Now can handle and extract messages from multiple toast containers

Other updates
- simplify mobile number validation
- capture OTP from user message

## How has this been tested?

A bit hacky, but to make sure we can capture multiple error messages through both API response and toast messages, I
- modified the code to only use `_wait_toast` task in `backend/src/chaturai/chatur/utils.py` and tested the registration with existing email and mobile (this will raise 2 errors: Email already taken, Mobile number is taken)
- then, modified the code to only use `_wait_api` task

Worked in both cases 👍 

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have ensured that my PR branch is up to date with `main`
